### PR TITLE
Fixed string truncation "bug" in scrapbook modal

### DIFF
--- a/src/extensions/arcade/slack/view.ts
+++ b/src/extensions/arcade/slack/view.ts
@@ -61,6 +61,9 @@ export class ChooseSessions {
             };
         }
 
+        let work = session.metadata.work.substring(0, 30);
+        work = work.substring(0, work.includes(' ') ? work.lastIndexOf(' ') : work.length);
+        
         return {
             type: "modal" as const,
             callback_id: Callbacks.CHOOSE_SESSIONS,
@@ -110,7 +113,7 @@ export class ChooseSessions {
                             {
                                 text: {
                                     type: "plain_text",
-                                    text: `${session.metadata.work.substring(0,30)} - ${session.createdAt.getMonth()}/${session.createdAt.getDate()}`,
+                                    text: `${work} - ${session.createdAt.getMonth()}/${session.createdAt.getDate()}`,
                                     emoji: true,
                                 },
                                 value: session.id,

--- a/src/extensions/arcade/slack/view.ts
+++ b/src/extensions/arcade/slack/view.ts
@@ -61,8 +61,8 @@ export class ChooseSessions {
             };
         }
 
-        let work = session.metadata.work.substring(0, 30);
-        work = work.substring(0, work.includes(' ') ? work.lastIndexOf(' ') : work.length);
+        let work = session.metadata.work.substring(0, 27);
+        work = work.substring(0, work.includes(' ') ? work.lastIndexOf(' ') : work.length) + "...";
         
         return {
             type: "modal" as const,


### PR DESCRIPTION
This is a very small fix. A member on Slack discovered that truncating messages at half words can lead to undesired results, so this just truncates the string to the end of the last word before the 30 character limit, unless it is just one long 30 character word (so the user can identify the correct session).

For more information look at https://hackclub.slack.com/archives/C0266FRGV/p1718717652692109