### PR TITLE
Added a couple new endpoints and ratelimiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.4.5",
         "dotenv-cli": "^7.4.2",
         "express": "^4.19.2",
+        "express-rate-limit": "^7.3.1",
         "get-urls": "^12.1.0",
         "lowdb": "^7.0.1",
         "prisma-json-types-generator": "^3.0.4",
@@ -1623,6 +1624,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.3.1.tgz",
+      "integrity": "sha512-BbaryvkY4wEgDqLgD18/NSy2lDO2jTuT9Y8c1Mpx0X63Yz0sYd5zN6KPe7UvpuSVvV33T6RaE1o1IVZQjHMYgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^16.4.5",
     "dotenv-cli": "^7.4.2",
     "express": "^4.19.2",
+    "express-rate-limit": "^7.3.1",
     "get-urls": "^12.1.0",
     "lowdb": "^7.0.1",
     "prisma-json-types-generator": "^3.0.4",


### PR DESCRIPTION
I added a couple new endpoints to the Arcade API as I'm currently working on an app that could use these endpoints. Added endpoints do the following:
- `/api/activity/:slackId` - gets the current activity of a user, if they're in an activity
- `/api/sessions/:slackId` - gets all the sessions of a user
- `/api/hours/:slackId` - returns all of the hours of a user

And additionally added ratelimiting to the API endpoints by passing middleware. Let me know if the ratelimit parameters can be modified