### PR TITLE
Removed "being" from "Tickets being spent"

### DIFF
--- a/src/extensions/arcade/slack/views/shop.ts
+++ b/src/extensions/arcade/slack/views/shop.ts
@@ -69,7 +69,7 @@ _How do I get tickets?_ You can get tickets once your sessions are approved (to 
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": `*Tickets being spent:* :tw_admission_tickets: ${spent}`
+                        "text": `*Tickets spent:* :tw_admission_tickets: ${spent}`
                     }
                 },
                 {


### PR DESCRIPTION
Removed the word "being" from "Tickets being spent" as the tickets have already been spent and processed.