### PR TITLE
Use new organized evidence library

### DIFF
--- a/src/extensions/arcade/lib/evidence.ts
+++ b/src/extensions/arcade/lib/evidence.ts
@@ -2,7 +2,6 @@
 
 import { Slack } from "../../../lib/bolt.js";
 import { Environment } from "../../../lib/constants.js";
-import { fetchEvidence } from "./helper.js";
         
 import getUrls from "get-urls";
 
@@ -50,6 +49,8 @@ export const Evidence = {
 
         return {
             activity,
+            evidenced: image !== undefined || onshape || github || githubCommit || githubPR,
+
             image,
             onshape,
             github,
@@ -121,8 +122,13 @@ export const Evidence = {
     },
 
     // Grabbers
+    async grabImages(messageTs: string, slackId: string) {
+        const evidence = await this.fetch(messageTs, slackId);
 
-    async grabImages(messageTs: string, slackId: string): Promise<string[]> {
+        return evidence.map(message => message.files ? message.files : []).flat().filter(file => file.mimetype && file.mimetype.includes("image"));
+    },
+
+    async grabImageURLs(messageTs: string, slackId: string): Promise<string[]> {
         const evidence = await this.fetch(messageTs, slackId);
 
         return evidence.map(message => message.files ? message.files : []).flat().filter(file => file.mimetype && file.mimetype.includes("image")).map(file => file.permalink_public).filter(i => i !== undefined);

--- a/src/extensions/arcade/lib/evidence.ts
+++ b/src/extensions/arcade/lib/evidence.ts
@@ -41,6 +41,7 @@ export const Evidence = {
         const activity = await this.checkActivity(evidence);
         const image = await this.checkImage(evidence);
         const {
+            links,
             onshape,
             github,
             githubCommit,
@@ -49,9 +50,10 @@ export const Evidence = {
 
         return {
             activity,
-            evidenced: image !== undefined || onshape || github || githubCommit || githubPR,
+            evidenced: image || onshape || github || githubCommit || githubPR || links,
 
-            image: image !== undefined,
+            links,
+            image,
             onshape,
             github,
             githubCommit,
@@ -64,10 +66,11 @@ export const Evidence = {
     },
 
     async checkImage(evidence: Awaited<ReturnType<typeof this.fetch>>) {
-        return evidence.find(message => message.files ? message.files.length > 0 : false);
+        return evidence.find(message => message.files ? message.files.length > 0 : false) !== undefined;
     },
 
     async checkLinks(evidence: Awaited<ReturnType<typeof this.fetch>>) {
+        let links = false;
         let onshape = false;
         let github = false;
         let githubCommit = false;
@@ -75,8 +78,10 @@ export const Evidence = {
         
         for (const message of evidence) {
             const urls = getUrls(message.text ? message.text : "");
-
+            
             for (const url of urls) {
+                links = true;
+
                 if (await this.isURL(url)) {
                     if (await this.isOnShape(url)) {
                         onshape = true;
@@ -91,6 +96,7 @@ export const Evidence = {
         }
 
         return {
+            links,
             onshape,
             github,
             githubCommit,

--- a/src/extensions/arcade/lib/evidence.ts
+++ b/src/extensions/arcade/lib/evidence.ts
@@ -1,0 +1,159 @@
+// Scans for evidence in threads
+
+import { Slack } from "../../../lib/bolt.js";
+import { Environment } from "../../../lib/constants.js";
+import { fetchEvidence } from "./helper.js";
+        
+import getUrls from "get-urls";
+
+/*
+Evidence types:
+- Screenshot (image)
+- Link (onshape)
+- Link (commit)
+- Link (pr)
+
+Required corrections:
+- Link (github but NOT github commit)
+*/
+export const Evidence = {
+    async fetch(messageTs: string, slackId: string) {
+        const evidence = await Slack.conversations.replies({
+            channel: Environment.MAIN_CHANNEL,
+            ts: messageTs
+        });
+    
+        if (!evidence || !evidence.messages) { throw new Error(`No evidence found for ${messageTs}`); }
+
+        return evidence.messages.filter(message => message.user === slackId);
+    },
+
+    // Checkers
+
+    async check({
+        messageTs,
+        slackId
+    }: {
+        messageTs: string,
+        slackId: string
+    }) {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        const activity = await this.checkActivity(evidence);
+        const image = await this.checkImage(evidence);
+        const {
+            onshape,
+            github,
+            githubCommit,
+            githubPR
+        } = await this.checkLinks(evidence);
+
+        return {
+            activity,
+            image,
+            onshape,
+            github,
+            githubCommit,
+            githubPR
+        };
+    },
+
+    async checkActivity(evidence: Awaited<ReturnType<typeof this.fetch>>) {
+        return evidence.length > 0;
+    },
+
+    async checkImage(evidence: Awaited<ReturnType<typeof this.fetch>>) {
+        return evidence.find(message => message.files ? message.files.length > 0 : false);
+    },
+
+    async checkLinks(evidence: Awaited<ReturnType<typeof this.fetch>>) {
+        let onshape = false;
+        let github = false;
+        let githubCommit = false;
+        let githubPR = false;
+        
+        for (const message of evidence) {
+            const urls = getUrls(message.text ? message.text : "");
+
+            for (const url of urls) {
+                if (await this.isURL(url)) {
+                    if (await this.isOnShape(url)) {
+                        onshape = true;
+                    } else if (await this.isGH(url)) {
+                        github = true;
+                        if (await this.isGHCommit(url)) {
+                            githubCommit = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return {
+            onshape,
+            github,
+            githubCommit,
+            githubPR
+        };
+    },
+
+    // URL checkers
+
+    async isURL(url: string) {
+        return getUrls(url).size > 0;
+    },
+
+    async isGH(url: string) {
+        return url.includes("github.com");
+    },
+
+    async isGHCommit(url: string) {
+        // does it match the pattern of a github commit?
+        // https://github.com/aboutdavid/hour-review-bot/commit/3779b6eb367169aab70fa6d2841791d85f8a8865
+        // borrowed from https://stackoverflow.com/questions/53362454/regex-to-mach-github-commit-url
+        return new RegExp('https://github\.com(?:/[^/]+)*/commit/[0-9a-f]{40}').test(url);
+    },
+
+    // async isGHPR(url: string) 
+
+    async isOnShape(url: string) {
+        return url.includes("cad.onshape.com");
+    },
+
+    // Grabbers
+
+    async grabImages(messageTs: string, slackId: string): Promise<string[]> {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        return evidence.map(message => message.files ? message.files : []).flat().filter(file => file.mimetype && file.mimetype.includes("image")).map(file => file.permalink_public).filter(i => i !== undefined);
+    },
+
+    async grabLinks(messageTs: string, slackId: string): Promise<string[]> {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        return evidence.map(message => this.getUrls(message.text ? message.text : "")).flat().filter(url => url !== undefined);
+    },
+
+    async grabOnShapeLinks(messageTs: string, slackId: string): Promise<string[]> {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        return (await this.grabLinks(messageTs, slackId)).filter(url => this.isOnShape(url));
+    },
+
+    async grabGHLinks(messageTs: string, slackId: string): Promise<string[]> {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        return (await this.grabLinks(messageTs, slackId)).filter(url => this.isGH(url));
+    },
+
+    async grabGHCommitLinks(messageTs: string, slackId: string): Promise<string[]> {
+        const evidence = await this.fetch(messageTs, slackId);
+
+        return (await this.grabGHLinks(messageTs, slackId)).filter(url => this.isGHCommit(url));
+    },
+
+    // Helpers
+    getUrls(message: string) {
+        return Array.from(getUrls(message));
+    }
+}

--- a/src/extensions/arcade/lib/evidence.ts
+++ b/src/extensions/arcade/lib/evidence.ts
@@ -51,7 +51,7 @@ export const Evidence = {
             activity,
             evidenced: image !== undefined || onshape || github || githubCommit || githubPR,
 
-            image,
+            image: image !== undefined,
             onshape,
             github,
             githubCommit,

--- a/src/extensions/arcade/lib/helper.ts
+++ b/src/extensions/arcade/lib/helper.ts
@@ -4,26 +4,7 @@ import { Environment } from "../../../lib/constants.js";
 import { prisma } from "../../../lib/prisma.js";
 import { updateTopLevel } from "../../slack/lib/lib.js";
 import { randomChoice } from "../../../lib/templates.js";
-
-export const fetchEvidence = async (messageTs: string, slackId: string) => {
-    // Check if the user posted anything in the thread
-    const evidence = await Slack.conversations.replies({
-        channel: Environment.MAIN_CHANNEL,
-        ts: messageTs
-    });
-
-    if (!evidence || !evidence.messages) { throw new Error(`No evidence found for ${messageTs}`); }
-
-    const activity = evidence.messages.filter(message => message.user === slackId).length > 0;
-
-    // Borrowed from david's code, thanks david!
-    const urlsExist = evidence.messages.find(message => message.user === slackId && (getUrls(message.text ? message.text : "").size > 0))
-    const imagesExist = evidence.messages.find(message => message.user === slackId && (message.files ? message.files.length > 0 : false))
-
-    const evidenced = urlsExist !== undefined || imagesExist !== undefined;
-
-    return { activity, evidenced };
-}
+import { Evidence } from "./evidence.js";
 
 const acceptedImageTypes = [
     "image/gif",
@@ -41,10 +22,11 @@ export const surfaceEvidence = async (messageTs: string, slackId: string) => {
 
     if (!evidence || !evidence.messages) { throw new Error(`No evidence found for ${messageTs}`); }
 
-    const image = (evidence.messages.filter(message => message.user === slackId && (message.files ? message.files.length > 0 : false))).at(-1);
+    //const image = (evidence.messages.filter(message => message.user === slackId && (message.files ? message.files.length > 0 : false))).at(-1);
+    const image = (await Evidence.grabImages(messageTs, slackId)).at(-1);
 
     // attach the evidence to the session
-    if (image?.files && image.files.length > 0) {
+    if (image) {
         const session = await prisma.session.findFirstOrThrow({
             where: {
                 messageTs: messageTs
@@ -55,10 +37,8 @@ export const surfaceEvidence = async (messageTs: string, slackId: string) => {
             return;
         }
 
-        console.log(JSON.stringify(image.files[0]));
-
-        if (acceptedImageTypes.includes(image.files[0]?.mimetype ?? "")) {
-            session.metadata.slack.attachment = image.files[0]?.permalink;
+        if (acceptedImageTypes.includes(image.mimetype ?? "")) {
+            session.metadata.slack.attachment = image.permalink;
         }
 
         const updatedSession = await prisma.session.update({
@@ -70,7 +50,7 @@ export const surfaceEvidence = async (messageTs: string, slackId: string) => {
             }
         });
 
-        console.log(`woah, pretty picture! ${image.files[0]?.permalink}`)
+        console.log(`woah, pretty picture! ${image.permalink}`)
 
         await updateTopLevel(updatedSession);
     }

--- a/src/extensions/arcade/watchers/hackhour.ts
+++ b/src/extensions/arcade/watchers/hackhour.ts
@@ -287,17 +287,10 @@ app.event("message", async ({ event }) => {
                 }
             });
 
-            const { activity, evidenced } = await Evidence.check({
+            const { activity, evidenced, image } = await Evidence.check({
                 messageTs: session.messageTs, 
                 slackId: user.slackUser!.slackId
             });
-            
-            let noteMessage = "_(note: screenshots of code don't count as proof - share git commits instead)_";
-            let shouldAddNote = false;
-
-            if ((event as any).files && (event as any).files.length > 0) {
-                shouldAddNote = true;
-            }
 
             if (!airtableSession.fields["Evidenced"] && evidenced) {
                 await Slack.chat.postMessage({
@@ -313,13 +306,13 @@ app.event("message", async ({ event }) => {
                                 "text": t('detect.evidence')
                             }
                         },
-                        ...(shouldAddNote ? [
+                        ...(image ? [
                             {
                                 "type": "context",
                                 "elements": [
                                     {
                                         "type": "mrkdwn",
-                                        "text": noteMessage
+                                        "text": "_(note: screenshots of code don't count as proof - share git commits instead)_"
                                     }
                                 ]
                             }
@@ -331,18 +324,7 @@ app.event("message", async ({ event }) => {
                     channel: Environment.MAIN_CHANNEL,
                     user: session.user.slackUser!.slackId,
                     thread_ts: session.messageTs,
-                    text: t('detect.activity'),
-                    blocks: shouldAddNote ? [
-                        {
-                            "type": "context",
-                            "elements": [
-                                {
-                                    "type": "mrkdwn",
-                                    "text": noteMessage
-                                }
-                            ]
-                        }
-                    ] : []
+                    text: t('detect.activity')
                 });
             }
 


### PR DESCRIPTION
adds checks & grabbers for images & links, and adds new types:
- onshape
- github
- github commit