### PR TITLE
Revert "Invalidate vsc extension sessions"

### DIFF
--- a/src/extensions/api/index.ts
+++ b/src/extensions/api/index.ts
@@ -190,14 +190,6 @@ express.get('/api/clock/:slackId', readLimit, async (req, res) => {
     }
 });
 
-express.get('/api/session', async (req, res) => {
-    // This is to invalidate all the sessions from the previous version of the vs code extension
-    return res.status(401).send({
-        ok: false,
-        error: 'Unauthorized',
-    })
-})
-
 /**
  * Get the latest session
  */


### PR DESCRIPTION
Reverts hackclub/hack-hour#98

This isn't needed anymore now that most sessions that were stuck in a retry loop are invalidated