### PR TITLE
More API Utilities

### DIFF
--- a/src/extensions/api/index.ts
+++ b/src/extensions/api/index.ts
@@ -613,8 +613,10 @@ express.post('/api/start/:slackId', limiter, async (req, res) => {
         }
     });
 
-    await updateController(session);
-    await updateTopLevel(session);
+    await Promise.all([
+        updateController(session),
+        updateTopLevel(session)
+    ])
 
     emitter.emit('start', session);
 
@@ -826,9 +828,7 @@ express.post('/api/goals/:slackId', limiter, async (req, res) => {
             })
         }
 
-        const updatedSession = await Session.changeGoal(session, req.body.id);
-
-        await updateTopLevel(updatedSession);
+        await Session.changeGoal(session, req.body.id);
 
         return res.status(200).send({
             ok: true,

--- a/src/extensions/api/index.ts
+++ b/src/extensions/api/index.ts
@@ -369,7 +369,7 @@ express.get('/api/goals/:slackId', readLimit, async (req, res) => {
         data: result.map(r => {
             return {
                 name: r.name,
-                minutes: r.minutes
+                minutes: r.minutes,
             }
         }),
     }
@@ -430,6 +430,7 @@ express.get('/api/history/:slackId', readLimit, async (req, res) => {
                 ended: r.completed || r.cancelled,
 
                 work: r.metadata?.work,
+                messageTs: r.messageTs,
             }
         })
     }
@@ -573,6 +574,7 @@ express.post('/api/start/:slackId', limiter, async (req, res) => {
             id: session.id,
             slackId: user.slackUser?.slackId,
             createdAt: session.createdAt,
+            messageTs: assertVal(topLevel!.ts),
         },
     });
 });
@@ -634,6 +636,7 @@ express.post('/api/cancel/:slackId', limiter, async (req, res) => {
                 id: session.id,
                 slackId: session.user.slackUser?.slackId,
                 createdAt: session.createdAt,
+                messageTs: session.messageTs,
             },
         });
     } catch (error) {
@@ -699,6 +702,7 @@ express.post('/api/pause/:slackId', limiter, async (req, res) => {
                 slackId: session.user.slackUser?.slackId,
                 createdAt: session.createdAt,
                 paused: updatedSession.paused,
+                messageTs: session.messageTs,
             },
         });
     } catch (error) {

--- a/src/lib/corelib.ts
+++ b/src/lib/corelib.ts
@@ -75,6 +75,19 @@ export class Session {
 
         return updatedSession;
     }
+
+    public static async changeGoal(session: SessionType, goalId: string) {
+        const updatedSession = await prisma.session.update({
+            where: {
+                id: session.id
+            },
+            data: {
+                goalId: goalId
+            }
+        })
+        
+        return updatedSession;
+    }
 }
 
 // TODO: Metadata management

--- a/src/lib/corelib.ts
+++ b/src/lib/corelib.ts
@@ -3,6 +3,7 @@ import type { Session as SessionType } from "@prisma/client";
 
 import { prisma } from "./prisma.js";
 import { emitter } from "./emitter.js";
+import { updateController, updateTopLevel } from "../extensions/slack/lib/lib.js";
 
 interface SessionAction {
     userId?: string;
@@ -85,6 +86,11 @@ export class Session {
                 goalId: goalId
             }
         })
+
+        await Promise.all([
+            updateController(updatedSession),
+            updateTopLevel(updatedSession)
+        ])
         
         return updatedSession;
     }


### PR DESCRIPTION
Add some more capabilities to the API, such as:

- Providing the `messageTs` property of sessions in more places
- Provide the goal `id` in the `/api/goals/:slackId` API
- Allow changing the goal of an active session by `POST`ing to the `/api/goals/:slackId` API
- Allow viewing shop info (spendable tickets, tickets pending review, tickets in orders, tickets spent) by `GET`ting the `/api/shop/:slackId` API