### PR TITLE
Limit to 50 hours on scrapbook selection

### DIFF
--- a/src/extensions/arcade/slack/scrapbook.ts
+++ b/src/extensions/arcade/slack/scrapbook.ts
@@ -47,6 +47,7 @@ Slack.action(Actions.CHOOSE_SESSIONS, async ({ ack, body }) => {
         // });
 
         const sessions = await prisma.session.findMany({
+            take: 50,
             where: {
                 userId: scrapbook?.userId,
                 // createdAt: {


### PR DESCRIPTION
The primary issue is Slack's API restricts the size of the view to "250kb" (250 * 1024 bits = 256,000 bits = 32,000 bytes)

https://api.slack.com/methods/views.update

Each session in the ultimate view object adds 300 bytes (javascript uses utf16 therefore 2 bytes per char) 

`{"text":{"type":"plain_text","text":"abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde - 7/10","emoji":true},"value":"123456123456123456123456"},` (146 chars)

32,000 bytes / 292 bytes per session = 109 sessions can fit into view payload assuming nothing else is there.

But more than just the sessions are included in the view which is why it's an issue even at lower session numbers.

This pull requests add a take operation to the database call to limit the number of session returned when selecting hours to 50, preventing this edge case.

https://www.prisma.io/docs/orm/prisma-client/queries/pagination


