### PR TITLE
arcade: show goals in scrapbook session select

### DIFF
--- a/src/extensions/arcade/slack/scrapbook.ts
+++ b/src/extensions/arcade/slack/scrapbook.ts
@@ -75,6 +75,13 @@ Slack.action(Actions.CHOOSE_SESSIONS, async ({ ack, body }) => {
                     }
                 ]
             },
+            include: {
+                goal: {
+                    select: {
+                        name: true,
+                    }
+                },
+            },
         });
 
         log(`\`\`\`${JSON.stringify(sessions)}\`\`\``)

--- a/src/extensions/arcade/slack/views/scrapbook.ts
+++ b/src/extensions/arcade/slack/views/scrapbook.ts
@@ -114,7 +114,10 @@ export class ChooseSessions {
                                     text: `${work} - ${session.createdAt.getMonth() + 1}/${session.createdAt.getDate()}`,
                                     emoji: true,
                                 },
-                                description: `Goal: ${session.goal.name}`,
+                                description: {
+                                    type: "plain_text",
+                                    text: `Goal: ${session.goal.name}`,
+                                },
                                 value: session.id,
                             }
                         }),

--- a/src/extensions/arcade/slack/views/scrapbook.ts
+++ b/src/extensions/arcade/slack/views/scrapbook.ts
@@ -114,6 +114,7 @@ export class ChooseSessions {
                                     text: `${work} - ${session.createdAt.getMonth() + 1}/${session.createdAt.getDate()}`,
                                     emoji: true,
                                 },
+                                description: `Goal: ${session.goal.name}`,
                                 value: session.id,
                             }
                         }),


### PR DESCRIPTION
Shows the goal associated with each session in the select list that hakkuun sends after you post in the scrapbook.

I didn't test this (I'm not sure _how_ to test it), but it's a pretty simple change so it should work