### PR TITLE
Include cancelled sessions in the /stats endpoint

### DIFF
--- a/src/extensions/api/index.ts
+++ b/src/extensions/api/index.ts
@@ -90,7 +90,7 @@ emitter.on('cancel', async (session: SessionType) => {
     await postEndpoints(session);
 });
 
-express.set('trust proxy', true) 
+express.set('trust proxy', true)
 
 express.use((req, res, next) => {
     const authHeader = req.headers['authorization'];
@@ -297,7 +297,10 @@ express.get('/api/stats/:slackId', readLimit, async (req, res) => {
     const result = await prisma.session.aggregate({
         where: {
             userId: slackUser.userId,
-            completed: true,
+            OR: [
+                {completed: true},
+                {cancelled: true}
+            ]
         },
         _sum: {
             elapsed: true,


### PR DESCRIPTION
Currently cancelled sessions (ended before 1hr) are excluded from the stats endpoint, but they count for hours, so I believe they should be included in the calculation