### PR TITLE
Add the /api/arcade/shop/ endpoint for better documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,17 @@ Get all items from the shop with stock if applicable
 
 Example Response:
 ```json
-[{“name”:”USB-C Charger”,”smallName”:”(30W)”,”description”:”Small, uses the latest GaN technology, & charges fast - pretty sweet!”,”hours”:6,”imageURL”:”https://cloud-lit9nkas9-hack-club-bot.vercel.app/051t9lfjeuml._ac_sl1500_.png”,”stock”:47} … ]
+[
+  {
+    "name": "USB-C Charger",
+    "smallName": "(30W)",
+    "description": "Small, uses the latest GaN technology, & charges fast - pretty sweet!",
+    "hours": 6,
+    "imageURL": "https://cloud-lit9nkas9-hack-club-bot.vercel.app/051t9lfjeuml._ac_sl1500_.png",
+    "stock": 47
+  }
+  // etc
+]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,18 @@ Example Response:
 }
 ```
 
+
 ### GET `/api/clock/:slackId`
 Depreciated.
 
 Responds with unix timestamp of the expected end time of the current session for the user.
+
+### GET `https://hackclub.com/api/arcade/shop/`
+Get all items from the shop with stock if applicable 
+
+Example Response:
+```json
+[{“name”:”USB-C Charger”,”smallName”:”(30W)”,”description”:”Small, uses the latest GaN technology, & charges fast - pretty sweet!”,”hours”:6,”imageURL”:”https://cloud-lit9nkas9-hack-club-bot.vercel.app/051t9lfjeuml._ac_sl1500_.png”,”stock”:47} … ]
+```
+
+


### PR DESCRIPTION
I want to add GET https://hackclub.com/api/arcade/shop/ to the README.md
While this doesn’t run on the hackhour subdomain, it still is an essential API point that is currently not documented well. Adding it to the other essential API points makes sense imo. 

Edit: grammar