### PR TITLE
Sort sessions by oldest instead of newest

### DIFF
--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -354,7 +354,7 @@ export const scrapbookMultifilter = async (filterRules: string[]) => {
     // const records = await AirtableAPI.Scrapbook.filter(filter);
     const records = await scrapbooks.select({
         filterByFormula: filter,
-        sort: [{ field: "Created At", direction: "desc" }],
+        sort: [{ field: "Created At", direction: "asc" }],
     }).all();
 
     return records as unknown as {


### PR DESCRIPTION
Since f6387616da58f3581249be09bf375a5ada25c9ac (introduced in #148), reviewers are sent to the most recent scrapbooks instead of the oldest.

