### PR TITLE
Reduce lines of user overview

### DIFF
--- a/src/extensions/review/view.ts
+++ b/src/extensions/review/view.ts
@@ -120,8 +120,7 @@ export class View {
                     "type": "mrkdwn",
                     "text":
 `*User Overview* ${pfps['info']}
-total hours logged: ${formatHour(hours)} hours
-total hours approved: ${formatHour(reviewed)} hours
+total hours (approved / logged): ${formatHour(reviewed)} / ${formatHour(hours)} hours
 sessions: ${sessions}
 flag: ${flagged == `✅ Didn't Commit Fraud` ? `none` : flagged}
 user category: ${category}


### PR DESCRIPTION
This prevents the need to press "see more" to see the `User Category` when reviewing.